### PR TITLE
feat: add LocalBusiness JSON-LD structured data to homepage

### DIFF
--- a/site/src/components/Seo.js
+++ b/site/src/components/Seo.js
@@ -2,7 +2,7 @@ import React from "react"
 import Helmet from "react-helmet"
 import { StaticQuery, graphql } from "gatsby"
 
-export const Seo = ({ description, lang, meta, keywords, title }) => (
+export const Seo = ({ description, lang, meta, keywords, title, jsonLd }) => (
   <StaticQuery
     query={graphql`
       query DefaultSEOQuery {
@@ -16,9 +16,7 @@ export const Seo = ({ description, lang, meta, keywords, title }) => (
       }
     `}
     render={data => {
-      const metaDescription = `${
-        data.site.siteMetadata.description
-      } ${description}`
+      const metaDescription = `${data.site.siteMetadata.description} ${description}`
       return (
         <Helmet
           htmlAttributes={{
@@ -69,6 +67,16 @@ export const Seo = ({ description, lang, meta, keywords, title }) => (
                 : []
             )
             .concat(meta)}
+          script={
+            jsonLd
+              ? [
+                  {
+                    type: `application/ld+json`,
+                    innerHTML: JSON.stringify(jsonLd),
+                  },
+                ]
+              : []
+          }
         />
       )
     }}

--- a/site/src/pages/index.js
+++ b/site/src/pages/index.js
@@ -11,7 +11,7 @@ const jsonLd = {
     "https://www.hamerlin.com/static/9b21fcca9af702f371e6781da3b5197d/c4f3a/hamerlin_hero.jpg",
   url: "https://www.hamerlin.com",
   telephone: "+507-221-5220",
-  email: "mailto:ventas@hamerlin.com",
+  email: "ventas@hamerlin.com",
   description:
     "Empresa panameña de control de plagas con más de 40 años de experiencia. Servicios de fumigación residencial y comercial, control de comején, roedores, insectos rastreros y voladores. Certificados MINSA.",
   address: {

--- a/site/src/pages/index.js
+++ b/site/src/pages/index.js
@@ -1,16 +1,39 @@
 import React from "react"
 import Layout from "../components/layout"
 import { Seo } from "../components/Seo"
-import HeroHeader from '../components/HeroHeader'
+import HeroHeader from "../components/HeroHeader"
+
+const jsonLd = {
+  "@context": "https://schema.org",
+  "@type": "LocalBusiness",
+  name: "Fumigadora Hamerlin, S.A.",
+  image:
+    "https://www.hamerlin.com/static/9b21fcca9af702f371e6781da3b5197d/c4f3a/hamerlin_hero.jpg",
+  url: "https://www.hamerlin.com",
+  telephone: "+507-221-5220",
+  email: "mailto:ventas@hamerlin.com",
+  description:
+    "Empresa panameña de control de plagas con más de 40 años de experiencia. Servicios de fumigación residencial y comercial, control de comején, roedores, insectos rastreros y voladores. Certificados MINSA.",
+  address: {
+    "@type": "PostalAddress",
+    streetAddress: "Calle Primera, Concepción",
+    addressLocality: "Juan Díaz, Ciudad de Panamá",
+    addressCountry: "PA",
+  },
+  areaServed: "Ciudad de Panamá",
+  priceRange: "$$",
+  openingHours: "Mo-Fr 08:00-17:00",
+}
 
 const IndexPage = () => (
-    <Layout>
-      <Seo
-        title="Inicio"
-        keywords={[`fumigadora`, `hamerlin`, `control de plagas`]}
-      />
-      <HeroHeader />
-    </Layout>
+  <Layout>
+    <Seo
+      title="Inicio"
+      keywords={[`fumigadora`, `hamerlin`, `control de plagas`]}
+      jsonLd={jsonLd}
+    />
+    <HeroHeader />
+  </Layout>
 )
 
 export default IndexPage


### PR DESCRIPTION
## Summary

Add Schema.org `LocalBusiness` JSON-LD structured data to the homepage so search engines can surface the business name, contact details, address, hours, and service area in local search results.

- Extended `Seo` to accept an optional `jsonLd` object and render it as a `<script type="application/ld+json">` tag via `react-helmet`.
- Added the client-provided `LocalBusiness` schema to the index page.
- Verified the script is rendered in the built `public/index.html`:

```html
<script type="application/ld+json">
{"@context":"https://schema.org","@type":"LocalBusiness","name":"Fumigadora Hamerlin, S.A.", ...}
</script>
```

Build passes locally with `yarn build`.


Link to Devin session: https://app.devin.ai/sessions/259aae7f8da54f258741ee8c96ece8be
Requested by: @horacioh
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/horacioh/hamerlin.com/pull/44" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->