### PR TITLE
feat(seo): SEO/AI-SEO foundations — meta/OG overhaul, richer JSON-LD, robots/sitemap/llms.txt, WhatsApp CTA

### DIFF
--- a/404.html
+++ b/404.html
@@ -1,17 +1,21 @@
-<!DOCTYPE html>
+<!doctype html>
 <html lang="es">
   <head>
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1" />
-    <title>404: Not found | Fumigadora Hamerlin, S.A.</title>
+    <title>404: Aquí no hay nada | Fumigadora Hamerlin, S.A.</title>
     <meta name="description" content="Página no encontrada." />
+    <meta name="robots" content="noindex" />
     <link rel="icon" href="/assets/favicon.ico" />
     <link rel="stylesheet" href="/styles.css" />
   </head>
   <body>
     <main class="notfound">
-      <h1>NOT FOUND</h1>
-      <p>You just hit a route that doesn&#39;t exist... the sadness.</p>
+      <h1>404</h1>
+      <p class="notfound-lead">Aquí no hay nada…</p>
+      <p>
+        igual que la cantidad de plagas que quedan después de que trabajamos.
+      </p>
       <p><a class="link" href="/">Volver al inicio</a></p>
     </main>
   </body>

--- a/index.html
+++ b/index.html
@@ -1,31 +1,55 @@
-<!DOCTYPE html>
+<!doctype html>
 <html lang="es">
   <head>
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1" />
-    <title>Inicio | Fumigadora Hamerlin, S.A.</title>
+    <title>
+      Fumigadora en Panamá | Control de Plagas — Fumigadora Hamerlin, S.A.
+    </title>
     <meta
       name="description"
-      content="Vive Libre de plagas con nuestro manejo integral. en Fumigadora Hamerlin llevamos mas de 30 años ayudando a nuestros clientes a estar libre de cualquier tipo de plagas: cucarachas, hormigas, ratones, gorgojos, comejen, murcielagos, animales exoticos..."
+      content="Vive libre de plagas con nuestro manejo integral. En Fumigadora Hamerlin llevamos más de 40 años ayudando a nuestros clientes en Panamá a estar libres de cucarachas, hormigas, ratones, gorgojos, comején, murciélagos y animales exóticos. Certificados MINSA."
     />
-    <meta name="keywords" content="fumigadora, hamerlin, control de plagas" />
+    <meta
+      name="keywords"
+      content="fumigadora, fumigación panamá, control de plagas, comején, hamerlin"
+    />
     <meta name="author" content="@hamerlin" />
 
+    <link rel="canonical" href="https://www.hamerlin.com/" />
+
     <!-- Open Graph -->
-    <meta property="og:title" content="Inicio" />
+    <meta
+      property="og:title"
+      content="Fumigadora en Panamá | Control de Plagas — Fumigadora Hamerlin"
+    />
     <meta
       property="og:description"
-      content="Vive Libre de plagas con nuestro manejo integral. en Fumigadora Hamerlin llevamos mas de 30 años ayudando a nuestros clientes a estar libre de cualquier tipo de plagas: cucarachas, hormigas, ratones, gorgojos, comejen, murcielagos, animales exoticos..."
+      content="Más de 40 años de experiencia en control de plagas en Panamá: comején, cucarachas, roedores, murciélagos y más. Certificados MINSA. ¡Llámanos o escríbenos por WhatsApp!"
     />
     <meta property="og:type" content="website" />
+    <meta property="og:url" content="https://www.hamerlin.com/" />
+    <meta
+      property="og:image"
+      content="https://www.hamerlin.com/assets/hamerlin_hero.jpg"
+    />
+    <meta property="og:locale" content="es_PA" />
+    <meta property="og:site_name" content="Fumigadora Hamerlin, S.A." />
 
     <!-- Twitter -->
-    <meta name="twitter:card" content="summary" />
+    <meta name="twitter:card" content="summary_large_image" />
     <meta name="twitter:creator" content="@hamerlin" />
-    <meta name="twitter:title" content="Inicio" />
+    <meta
+      name="twitter:title"
+      content="Fumigadora en Panamá | Control de Plagas — Fumigadora Hamerlin"
+    />
     <meta
       name="twitter:description"
-      content="Vive Libre de plagas con nuestro manejo integral. en Fumigadora Hamerlin llevamos mas de 30 años ayudando a nuestros clientes a estar libre de cualquier tipo de plagas: cucarachas, hormigas, ratones, gorgojos, comejen, murcielagos, animales exoticos..."
+      content="Más de 40 años de experiencia en control de plagas en Panamá: comején, cucarachas, roedores, murciélagos y más. Certificados MINSA."
+    />
+    <meta
+      name="twitter:image"
+      content="https://www.hamerlin.com/assets/hamerlin_hero.jpg"
     />
 
     <link rel="icon" href="/assets/favicon.ico" />
@@ -51,7 +75,69 @@
         },
         "areaServed": "Ciudad de Panamá",
         "priceRange": "$$",
-        "openingHours": "Mo-Fr 08:00-17:00"
+        "openingHours": "Mo-Fr 08:00-17:00",
+        "contactPoint": {
+          "@type": "ContactPoint",
+          "telephone": "+507-6030-8417",
+          "contactType": "customer service",
+          "availableLanguage": "Spanish"
+        },
+        "knowsAbout": [
+          "control de comején",
+          "control de cucarachas e insectos rastreros",
+          "control de roedores",
+          "control de murciélagos y animales exóticos",
+          "fumigación residencial",
+          "fumigación comercial"
+        ],
+        "hasOfferCatalog": {
+          "@type": "OfferCatalog",
+          "name": "Servicios de control de plagas",
+          "itemListElement": [
+            {
+              "@type": "Offer",
+              "itemOffered": {
+                "@type": "Service",
+                "name": "Control de comején"
+              }
+            },
+            {
+              "@type": "Offer",
+              "itemOffered": {
+                "@type": "Service",
+                "name": "Control de cucarachas e insectos rastreros"
+              }
+            },
+            {
+              "@type": "Offer",
+              "itemOffered": {
+                "@type": "Service",
+                "name": "Control de roedores"
+              }
+            },
+            {
+              "@type": "Offer",
+              "itemOffered": {
+                "@type": "Service",
+                "name": "Control de murciélagos y animales exóticos"
+              }
+            },
+            {
+              "@type": "Offer",
+              "itemOffered": {
+                "@type": "Service",
+                "name": "Fumigación residencial"
+              }
+            },
+            {
+              "@type": "Offer",
+              "itemOffered": {
+                "@type": "Service",
+                "name": "Fumigación comercial"
+              }
+            }
+          ]
+        }
       }
     </script>
   </head>
@@ -59,12 +145,18 @@
     <picture class="hero-bg">
       <source
         type="image/webp"
-        srcset="/assets/hamerlin_hero-800.webp 800w, /assets/hamerlin_hero.webp 1200w"
+        srcset="
+          /assets/hamerlin_hero-800.webp  800w,
+          /assets/hamerlin_hero.webp     1200w
+        "
         sizes="100vw"
       />
       <img
         src="/assets/hamerlin_hero.jpg"
-        srcset="/assets/hamerlin_hero-800.jpg 800w, /assets/hamerlin_hero.jpg 1200w"
+        srcset="
+          /assets/hamerlin_hero-800.jpg  800w,
+          /assets/hamerlin_hero.jpg     1200w
+        "
         sizes="100vw"
         alt="Man working outdoors"
         aria-label="Man working outdoors"
@@ -74,7 +166,13 @@
 
     <main class="hero">
       <div class="logo-wrap">
-        <svg class="logo" width="250" viewBox="0 0 292 62" role="img" aria-labelledby="logoTitle">
+        <svg
+          class="logo"
+          width="250"
+          viewBox="0 0 292 62"
+          role="img"
+          aria-labelledby="logoTitle"
+        >
           <title id="logoTitle">Fumigadora Hamerlin Logo</title>
           <g fill="none" fill-rule="evenodd">
             <path
@@ -131,10 +229,30 @@
             <span class="emoji" aria-label="Electronic email emoji">📬</span>
           </p>
           <p class="value">
-            <a class="link" href="mailto:ventas@hamerlin.com">ventas@hamerlin.com</a>
+            <a class="link" href="mailto:ventas@hamerlin.com"
+              >ventas@hamerlin.com</a
+            >
           </p>
         </div>
       </footer>
     </main>
+
+    <a
+      class="whatsapp-fab"
+      href="https://wa.me/50760308417?text=Hola%2C%20quiero%20una%20cotizaci%C3%B3n%20de%20fumigaci%C3%B3n"
+      aria-label="Escríbenos por WhatsApp"
+    >
+      <svg
+        viewBox="0 0 32 32"
+        width="28"
+        height="28"
+        aria-hidden="true"
+        fill="currentColor"
+      >
+        <path
+          d="M16.004 3.2c-7.06 0-12.8 5.74-12.8 12.8 0 2.26.59 4.46 1.71 6.4L3.2 28.8l6.58-1.67a12.74 12.74 0 0 0 6.22 1.6h.01c7.06 0 12.79-5.74 12.79-12.8 0-3.42-1.33-6.63-3.75-9.05a12.72 12.72 0 0 0-9.05-3.68zm0 23.36h-.01c-1.99 0-3.94-.53-5.64-1.54l-.4-.24-3.9.99 1.04-3.8-.26-.42a10.6 10.6 0 0 1-1.63-5.65c0-5.87 4.78-10.64 10.66-10.64 2.85 0 5.52 1.11 7.53 3.12a10.58 10.58 0 0 1 3.12 7.53c0 5.87-4.78 10.65-10.65 10.65zm5.84-7.97c-.32-.16-1.89-.93-2.19-1.04-.29-.11-.51-.16-.72.16-.21.32-.83 1.04-1.01 1.25-.19.21-.37.24-.69.08-.32-.16-1.35-.5-2.57-1.59-.95-.85-1.59-1.9-1.78-2.22-.19-.32-.02-.49.14-.65.14-.14.32-.37.48-.56.16-.19.21-.32.32-.53.11-.21.05-.4-.03-.56-.08-.16-.72-1.73-.98-2.37-.26-.62-.52-.54-.72-.55h-.61c-.21 0-.56.08-.85.4-.29.32-1.12 1.09-1.12 2.66s1.15 3.09 1.31 3.3c.16.21 2.26 3.45 5.47 4.84.76.33 1.36.53 1.83.68.77.24 1.47.21 2.02.13.62-.09 1.89-.77 2.16-1.52.27-.75.27-1.39.19-1.52-.08-.13-.29-.21-.61-.37z"
+        />
+      </svg>
+    </a>
   </body>
 </html>

--- a/index.html
+++ b/index.html
@@ -73,7 +73,7 @@
           "addressLocality": "Juan Díaz, Ciudad de Panamá",
           "addressCountry": "PA"
         },
-        "areaServed": "Ciudad de Panamá",
+        "areaServed": { "@type": "Country", "name": "Panamá" },
         "priceRange": "$$",
         "openingHours": "Mo-Fr 08:00-17:00",
         "contactPoint": {

--- a/llms.txt
+++ b/llms.txt
@@ -1,7 +1,8 @@
 # Fumigadora Hamerlin, S.A.
 
 > Empresa panameña de control de plagas con más de 40 años de experiencia,
-> certificada por el MINSA (Ministerio de Salud de Panamá).
+> certificada por el MINSA (Ministerio de Salud de Panamá). Atendemos hogares
+> y negocios en todo Panamá.
 
 ## Qué hacemos
 
@@ -11,12 +12,64 @@ Servicios de manejo integral de plagas para hogares y negocios:
 - Control de cucarachas e insectos rastreros
 - Control de roedores (ratones y ratas)
 - Control de murciélagos y animales exóticos
-- Control de gorgojos, hormigas e insectos voladores
-- Fumigación residencial y comercial (restaurantes, hoteles, oficinas)
+- Control de gorgojos, hormigas e insectos voladores (mosquitos, moscas)
+- Fumigación residencial y comercial (restaurantes, hoteles, oficinas, bodegas, escuelas)
 
 ## Área de servicio
 
-Ciudad de Panamá y área metropolitana, Panamá.
+Todo Panamá: Ciudad de Panamá y área metropolitana, Panamá Oeste (Arraiján,
+La Chorrera), Colón, y el interior del país. Consulte disponibilidad para su
+provincia por teléfono o WhatsApp.
+
+## Dónde suelen aparecer las plagas (señales de que nos necesita)
+
+- **Comején / termitas**: túneles de barro en paredes y zócalos, madera hueca
+  al golpearla, puertas y marcos de ventanas, muebles de madera, techos y
+  vigas, alas desprendidas cerca de ventanas. Muy común en el clima tropical
+  húmedo de Panamá.
+- **Cucarachas**: cocinas (detrás de estufas y refrigeradoras), baños,
+  desagües, cajas de cartón almacenadas, restaurantes y depósitos de comida.
+- **Roedores (ratas y ratones)**: cielorrasos y áticos, bodegas, cocinas,
+  jardines con maleza, cables roídos, excremento en esquinas y gavetas.
+- **Hormigas**: cocinas y despensas, marcos de ventanas, jardines, líneas
+  visibles de hormigas hacia fuentes de comida.
+- **Mosquitos**: agua estancada en floreros, llantas, canales de lluvia y
+  charcos; importantes por dengue y otras enfermedades en Panamá.
+- **Gorgojos**: arroz, granos, harinas y alimentos secos almacenados en
+  despensas, depósitos y comercios.
+- **Murciélagos**: áticos, cielorrasos, espacios entre techo y paredes;
+  manchas oscuras y guano cerca de puntos de entrada.
+
+## Cómo controlamos las plagas
+
+Aplicamos Manejo Integrado de Plagas (MIP): inspección, identificación,
+tratamiento con productos aprobados por el MINSA y prevención.
+
+- **Comején**: inspección de la estructura, tratamiento localizado de la
+  madera afectada e inyección/barreras químicas en suelo y estructura para
+  eliminar la colonia y prevenir reinfestación.
+- **Cucarachas e insectos rastreros**: aplicación de gel-cebo y aspersión
+  residual en grietas, hendiduras y puntos de anidación; seguimiento para
+  cortar el ciclo reproductivo.
+- **Roedores**: inspección de puntos de entrada, estaciones de cebo y trampas
+  ubicadas estratégicamente, y recomendaciones de exclusión (sellado de
+  accesos).
+- **Insectos voladores (mosquitos, moscas)**: nebulización/termonebulización
+  de áreas afectadas y eliminación de criaderos (agua estancada).
+- **Murciélagos y animales exóticos**: manejo y exclusión sin dañar a los
+  animales, sellado de puntos de entrada y limpieza/desinfección de guano.
+- **Gorgojos y plagas de granos**: tratamiento de áreas de almacenamiento y
+  recomendaciones de manejo de producto almacenado.
+
+Los tratamientos son seguros para familias y mascotas siguiendo las
+indicaciones de reingreso que entrega nuestro personal.
+
+## Por qué elegirnos
+
+- Más de 40 años de experiencia en Panamá.
+- Certificados y regulados por el MINSA.
+- Atención a residencias, comercios, restaurantes, hoteles y oficinas.
+- Cotizaciones rápidas por teléfono o WhatsApp.
 
 ## Contacto
 

--- a/llms.txt
+++ b/llms.txt
@@ -1,0 +1,28 @@
+# Fumigadora Hamerlin, S.A.
+
+> Empresa panameña de control de plagas con más de 40 años de experiencia,
+> certificada por el MINSA (Ministerio de Salud de Panamá).
+
+## Qué hacemos
+
+Servicios de manejo integral de plagas para hogares y negocios:
+
+- Control de comején (termitas)
+- Control de cucarachas e insectos rastreros
+- Control de roedores (ratones y ratas)
+- Control de murciélagos y animales exóticos
+- Control de gorgojos, hormigas e insectos voladores
+- Fumigación residencial y comercial (restaurantes, hoteles, oficinas)
+
+## Área de servicio
+
+Ciudad de Panamá y área metropolitana, Panamá.
+
+## Contacto
+
+- Teléfonos: +507 221-5220 / +507 996-0671
+- WhatsApp: +507 6030-8417 (https://wa.me/50760308417)
+- Email: ventas@hamerlin.com
+- Dirección: Calle Primera, Concepción, Juan Díaz, Ciudad de Panamá, Panamá
+- Horario: lunes a viernes, 8:00 a.m. – 5:00 p.m.
+- Sitio web: https://www.hamerlin.com

--- a/robots.txt
+++ b/robots.txt
@@ -1,0 +1,19 @@
+User-agent: *
+Allow: /
+
+User-agent: GPTBot
+Allow: /
+
+User-agent: ChatGPT-User
+Allow: /
+
+User-agent: ClaudeBot
+Allow: /
+
+User-agent: PerplexityBot
+Allow: /
+
+User-agent: Google-Extended
+Allow: /
+
+Sitemap: https://www.hamerlin.com/sitemap.xml

--- a/sitemap.xml
+++ b/sitemap.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
+  <url>
+    <loc>https://www.hamerlin.com/</loc>
+    <changefreq>monthly</changefreq>
+    <priority>1.0</priority>
+  </url>
+</urlset>

--- a/styles.css
+++ b/styles.css
@@ -117,6 +117,27 @@ body {
   transform-origin: center left;
 }
 
+.whatsapp-fab {
+  position: fixed;
+  right: 20px;
+  bottom: 20px;
+  z-index: 2;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 56px;
+  height: 56px;
+  border-radius: 50%;
+  background-color: #25d366;
+  color: #fff;
+  box-shadow: 0 4px 12px rgba(0, 0, 0, 0.35);
+  transition: transform 0.15s ease-in-out;
+}
+
+.whatsapp-fab:hover {
+  transform: scale(1.08);
+}
+
 .notfound {
   min-height: 100vh;
   display: flex;

--- a/styles.css
+++ b/styles.css
@@ -149,6 +149,17 @@ body {
   color: var(--color-lightgray);
 }
 
+.notfound h1 {
+  font-size: 72px;
+  margin: 0 0 8px;
+  color: var(--color-accent);
+}
+
+.notfound-lead {
+  font-size: 24px;
+  margin: 0;
+}
+
 /* tablet / desktop: lay contact boxes out in a row (theme breakpoint 52em) */
 @media (min-width: 52em) {
   .contact {


### PR DESCRIPTION
## Summary
Phase 1 (code) of the online-presence action plan — technical SEO + AI-SEO foundations, no new build steps:

- **Titles/meta**: replaced the generic `Inicio` title with `Fumigadora en Panamá | Control de Plagas — Fumigadora Hamerlin, S.A.` across `<title>`, OG and Twitter tags; fixed the "30 años" vs "40 años" inconsistency (now 40, matching JSON-LD) and cleaned up accents.
- **Sharing**: added `og:url`, `og:image`, `og:locale` (`es_PA`), `og:site_name`, `twitter:image`, `summary_large_image`, and a `rel=canonical` — WhatsApp/Facebook shares previously rendered without an image or URL.
- **JSON-LD**: extended `LocalBusiness` with `contactPoint` (WhatsApp number), `knowsAbout`, and a `hasOfferCatalog` listing the six services (comején, cucarachas, roedores, murciélagos/exóticos, fumigación residencial/comercial); `areaServed` is now the whole country (`{"@type": "Country", "name": "Panamá"}`).
- **New root files**: `robots.txt` (explicitly allows GPTBot/ClaudeBot/PerplexityBot/Google-Extended + sitemap ref), `sitemap.xml`, and `llms.txt` — an expanded plain-text business summary for AI answer engines covering nationwide service area, common places each pest appears (señales de que nos necesita), and how each pest is controlled (MIP methodology).
- **Conversion**: sticky green WhatsApp FAB (bottom-right, `wa.me` link with pre-filled quote message) + `.whatsapp-fab` styles.

Follow-ups (not in this PR): Search Console/analytics setup, service pages, quote form — see the action plan.

Link to Devin session: https://app.devin.ai/sessions/18d60aca1d794a628e064422d8e87641
Requested by: @horacioh
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/horacioh/hamerlin.com/pull/47" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->